### PR TITLE
fix: handle non-string values in delta files

### DIFF
--- a/lib/delta-file.js
+++ b/lib/delta-file.js
@@ -221,14 +221,21 @@ function toStatements(triples) {
       return sparqlEscapeUri(value);
     } else if (type === 'literal' || type === 'typed-literal') {
       if (datatype)
-        return `${sparqlEscapeString(value)}^^${sparqlEscapeUri(datatype)}`;
+        // value can also be a number, depending on the whims of virtuoso's json output,
+        // the whims of the "mu" helper lib, or, I don't know, the weather.
+        // note: this does not mean that all numbers come in as numbers of course, that would
+        // be too easy.
+        // Depending on whether the producing side used a SELECT or a CONSTRUCT query,
+        // numbers can be represented either as strings or as json numerals
+        // So we call `toString`, close our eyes, and go to our happy place.
+        return `${sparqlEscapeString(value.toString())}^^${sparqlEscapeUri(datatype)}`;
       else if (lang)
-        return `${sparqlEscapeString(value)}@${lang}`;
+        return `${sparqlEscapeString(value.toString())}@${lang}`;
       else
-        return `${sparqlEscapeString(value)}`;
+        return `${sparqlEscapeString(value.toString())}`;
     } else
       console.log(`Don't know how to escape type ${type}. Will escape as a string.`);
-    return sparqlEscapeString(value);
+    return sparqlEscapeString(value.toString());
   };
   return triples.map(function(t) {
     const subject = escape(t.subject);


### PR DESCRIPTION
because the sparqlEscapeString helper assumes its argument is a string without checking, the only reason this was working is that numerical values were included as strings in the JSON responses from virtuoso.
However, that's only for SELECT queries, if you use CONSTRUCT, they are included as JSON numerals, and as such they crash here when being ingested